### PR TITLE
Leveling bug

### DIFF
--- a/src/MixxitListener.java
+++ b/src/MixxitListener.java
@@ -1101,22 +1101,23 @@ public class MixxitListener extends PluginListener
         continue;
       }
       ((MixxitPlayer)this.playerList.get(i)).exp += amount;
-      player.sendMessage("§eYou gain experience (" + this.playerList.get(i).exp + ")!");
+      player.sendMessage("ï¿½eYou gain experience (" + this.playerList.get(i).exp + ")!");
+
+      for (int ilevel = 1; ilevel < 41; ilevel++)
+      {
+    	  if (this.playerList.get(i).exp == (ilevel * 10) * ilevel)
+    	  {
+    		  setPlayerLevel(player, ilevel);
+    	  }
+      }
+      
       Random generator = new Random();
       int index = generator.nextInt(100);
 
       if (index != 1)
         continue;
       ((MixxitPlayer)this.playerList.get(i)).melee += 1;
-      player.sendMessage("§9You get better at melee! (" + this.playerList.get(i).melee + ")!");
-      
-      for (int ilevel = 1; ilevel < 41; ilevel++)
-      {
-    	  if (this.playerList.get(i).exp == (i * 10) * i)
-    	  {
-    		  setPlayerLevel(player, ilevel);
-    	  }
-      }
+      player.sendMessage("ï¿½9You get better at melee! (" + this.playerList.get(i).melee + ")!");
     }
   }
 
@@ -1450,7 +1451,7 @@ public class MixxitListener extends PluginListener
          // player.sendMessage("Debug - missed");
           if (getCombatLog(player) == 1)
           {
-            player.sendMessage("§7You try to strike a " + m.getName() + " HP: (" + m.getHealth() + ") but miss! Your HP: " + getPlayerHP(player)+ "/" + getMaxBaseHealth(player) );
+            player.sendMessage("ï¿½7You try to strike a " + m.getName() + " HP: (" + m.getHealth() + ") but miss! Your HP: " + getPlayerHP(player)+ "/" + getMaxBaseHealth(player) );
           }
           else
           {
@@ -1546,7 +1547,7 @@ public class MixxitListener extends PluginListener
         }
         if (getCombatLog(player) != 1)
           continue;
-        player.sendMessage("§7You try to strike a " + p.getName() + " HP: (" + getPlayerHP(p) + ") but miss! Your HP: " + getPlayerHP(player)+ "/" + getMaxBaseHealth(player) );
+        player.sendMessage("ï¿½7You try to strike a " + p.getName() + " HP: (" + getPlayerHP(p) + ") but miss! Your HP: " + getPlayerHP(player)+ "/" + getMaxBaseHealth(player) );
       }
       else
       {
@@ -1573,7 +1574,7 @@ public class MixxitListener extends PluginListener
         if (getPlayerHP(p) < thisdmg)
         {
           player.sendMessage("You have slain " + p.getName() + "!");
-          p.sendMessage("§cYou have been slain by " + player.getName() + "!");
+          p.sendMessage("ï¿½cYou have been slain by " + player.getName() + "!");
 
           DoPlayerDeath(p);
         } else {
@@ -1581,7 +1582,7 @@ public class MixxitListener extends PluginListener
           this.totalplydmg += thisdmg;
           if (getCombatLog(p) == 1)
           {
-            p.sendMessage("§cYou have been hit by " + player.getName() + " for " + thisdmg + " damage. Your HP: " + getPlayerHP(p) + "/" + getMaxBaseHealth(player) + " Their HP: " + getPlayerHP(player));
+            p.sendMessage("ï¿½cYou have been hit by " + player.getName() + " for " + thisdmg + " damage. Your HP: " + getPlayerHP(p) + "/" + getMaxBaseHealth(player) + " Their HP: " + getPlayerHP(player));
           }
           else {
             if (getCombatLog(p) != 2)


### PR DESCRIPTION
The leveling logic was checking the wrong variable (i) instead of (ilevel), and also should occur before the melee check, otherwise if the random 1/100 chance fails the player wont level.

I'm having trouble with the file encoding to make colors work on my Mac, so please double-check this on your end when merging this fix.
